### PR TITLE
Implicit english declaring

### DIFF
--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -585,7 +585,8 @@ sub _get_controldata {
     my %controldata;
     my $ans;
 
-    $ans = qx{ $PGCTRLDATA "$datadir" 2>/dev/null };
+    # Implicit language declaring to avoid translation issues
+    $ans = qx{ LANG=en_US $PGCTRLDATA "$datadir" 2>/dev/null };
 
     # Parse the output of pg_controldata.
     # This output is quite stable between pg versions, but we might need to sort


### PR DESCRIPTION
Implicit english language declaring to avoid translation issues (Russian in my case). In my job I do have to use localized PostgreSQL version, so `pg_controldata` returns the output in Russian and RA returns `OCF_ERR_INSTALLED`