### PR TITLE
PostgreSQL deb dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Homepage: http://clusterlabs.github.io/PAF/
 
 Package: resource-agents-paf
 Architecture: all
-Depends: ${misc:Depends}, resource-agents, perl, pacemaker (>= 1.1.13) | pacemaker-remote (>= 1.1.13), corosync (>= 2.0.0)
+Depends: ${misc:Depends}, resource-agents, perl, pacemaker (>= 1.1.13) | pacemaker-remote (>= 1.1.13), corosync (>= 2.0.0), postgresql (>= 9.6), postgresql-contrib (>= 9.6), postgresql-client (>= 9.6)
 Description: PostgreSQL resource agent for Pacemaker
  PostgreSQL Automatic Failover (aka. PAF) is a new OCF resource Agent
  dedicated to PostgreSQL. Its original wish is to keep a clear limit between

--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -585,7 +585,8 @@ sub _get_controldata {
     my %controldata;
     my $ans;
 
-    $ans = qx{ $PGCTRLDATA "$datadir" 2>/dev/null };
+    # Implicit language declaring to avoid translation issues
+    $ans = qx{ LANG=en_US $PGCTRLDATA "$datadir" 2>/dev/null };
 
     # Parse the output of pg_controldata.
     # This output is quite stable between pg versions, but we might need to sort


### PR DESCRIPTION
Just found out PAF has no PostgreSQL dependencies while constructing another package depending on PAF