### PR TITLE
FIX: empty nodename for pacemaker 1.1.7

### DIFF
--- a/lib/OCF_Functions.pm
+++ b/lib/OCF_Functions.pm
@@ -438,7 +438,7 @@ sub ocf_local_nodename {
             $nodename = qx{ crm_node -n } if $? == 0;
         }
     }
-    else {
+    if (not defined $nodename) {
         # otherwise use uname -n
         $nodename = qx { uname -n };
     }


### PR DESCRIPTION
Consider the function:

https://github.com/ClusterLabs/PAF/blob/c75746c6040f492109b09e27f8958627840d5edf/lib/OCF_Functions.pm#L424-L448

If I have Pacemaker 1.1.7 installed, the script follows the branch on line 429, but it doesn't follow the branch on line 436, so the `$nodename` variable is never assigned

This PR affects only 1.x version of PAF, because PAF 2.x is incompatible with Pacemaker < 1.1.13