### PR TITLE
Fixed a problem with _get_master_score failing in pacemaker-2.1.0

### DIFF
--- a/script/pgsqlms
+++ b/script/pgsqlms
@@ -359,7 +359,7 @@ sub _get_master_score {
 
     $node_arg = sprintf '--node "%s"', $node if defined $node and $node ne '';
 
-    $score = qx{ $CRM_MASTER --quiet --get-value $node_arg 2> /dev/null };
+    $score = qx{ $CRM_MASTER --quiet --query $node_arg 2> /dev/null };
 
     return '' unless $? == 0 and defined $score;
 


### PR DESCRIPTION
In pacemaker-2.1.0, the `--get-value` option of the crm_master command now fails if no argument is passed.
This has caused the problem in issue #194.

In this PR, the problem is solved by using the `--query` option instead of the `--get-value` option.