### PR TITLE
debian/watch: Look at tags instead of releases

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,3 @@
 version=3
 opts=filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/PAF-$1\.tar\.gz/,uversionmangle=s/_beta/~beta/;s/_alpha/~alpha/;s/_rc/~rc/ \
-  https://github.com/ClusterLabs/PAF/releases .*/v?(\d\S+)\.tar\.gz
+  https://github.com/ClusterLabs/PAF/tags .*/v?(\d\S+)\.tar\.gz


### PR DESCRIPTION
The old URL doesn't work with uscan(1) anymore.